### PR TITLE
Support private fields in class instances

### DIFF
--- a/src/createEventEmitterProxy.js
+++ b/src/createEventEmitterProxy.js
@@ -12,10 +12,17 @@ module.exports = function createEventEmitterProxy (initialTarget, opts) {
   let target = initialTarget
 
   const proxy = new Proxy({}, {
-    get: (_, name) => {
+    get: (_, name, receiver) => {
       // override `setTarget` access
       if (name === 'setTarget') return setTarget
-      return target[name]
+
+      const value = target[name];
+      if (value instanceof Function) {
+        return function (...args) {
+          return value.apply(this === receiver ? target : this, args);
+        };
+      }
+      return value;
     },
     set: (_, name, value) => {
       // allow `setTarget` overrides

--- a/src/createSwappableProxy.js
+++ b/src/createSwappableProxy.js
@@ -3,10 +3,17 @@ module.exports = function createSwappableProxy (initialTarget) {
   let target = initialTarget
 
   const proxy = new Proxy({}, {
-    get: (_, name) => {
+    get: (_, name, receiver) => {
       // override `setTarget` access
       if (name === 'setTarget') return setTarget
-      return target[name]
+
+      const value = target[name];
+      if (value instanceof Function) {
+        return function (...args) {
+          return value.apply(this === receiver ? target : this, args);
+        };
+      }
+      return value;
     },
     set: (_, name, value) => {
       // allow `setTarget` overrides

--- a/test/createSwappableProxy.js
+++ b/test/createSwappableProxy.js
@@ -2,7 +2,6 @@ const test = require('tape')
 const EventEmitter = require('events')
 const { createSwappableProxy } = require('../src/index')
 
-
 test('createSwappableProxy - basic', (t) => {
   const original = { value: 1 }
   const next = { value: 2 }
@@ -30,6 +29,43 @@ test('createSwappableProxy - setTarget twice ', (t) => {
   proxy.setTarget(two)
   t.equal(proxy.value, 2, 'value comes from two')
 
+
+  t.end()
+})
+
+test('createSwappableProxy - calling a method', (t) => {
+  const underlying = {
+    foo() {
+      return this.bar();
+    },
+    bar() {
+      return 42;
+    }
+  }
+  const proxy = createSwappableProxy(underlying)
+
+  t.equal(proxy.foo(), 42)
+
+  t.end()
+})
+
+test('createSwappableProxy - calling a method on an instance of a class with private fields', (t) => {
+  class Foo {
+    #qux;
+
+    bar() {
+      this.#qux = true;
+      return this.#baz();
+    }
+
+    #baz() {
+      return [this.#qux, 42];
+    }
+  }
+  const underlying = new Foo()
+  const proxy = createSwappableProxy(underlying)
+
+  t.deepEqual(proxy.bar(), [true, 42])
 
   t.end()
 })


### PR DESCRIPTION
When creating a proxy for an instance of a class, ensure that if a method forwarded to the instance can access private fields within that class. For instance:

``` javascript
class Foo {
  #qux;

  bar() {
    this.#qux = true;
    return this.#baz();
  }

  #baz() {
    return [this.#qux, 42];
  }
}

const foo = new Foo();
const proxy = createSwappableProxy(foo);
proxy.bar();
```

As it stands, this produces the TypeError:

    Cannot write private member #qux to an object whose class did not declare it

If we call `this.#baz()` before we set `#qux`, then we get:

    Receiver must be an instance of class Foo

We get this error because `proxy.bar` returns a function that is bound to the proxy object and not our Foo object. Therefore, if we are know we are trying to access a method on Foo we need to get the proxy to return a wrapper function which ensures that when the method is called, it is done so with our Foo instance as `this` and not the proxy object. This is explained here in the MDN docs:
<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#no_private_property_forwarding>

---

Fixes #2.