### PR TITLE
Scope package under `@metamask`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Creates a `Proxy` around any object. Retarget the proxy with `setTarget`.
 
 ##### usage
 ```js
-const { createSwappableProxy } = require('swappable-obj-proxy')
+const { createSwappableProxy } = require('@metamask/swappable-obj-proxy')
 
 const original = { sayHello: () => 'hi' }
 const next = { sayHello: () => 'haay' }
@@ -21,7 +21,7 @@ Creates a `Proxy` around an `EventEmitter`. If the proxy has `setTarget` called 
 
 ##### usage
 ```js
-const { createEventEmitterProxy } = require('swappable-obj-proxy')
+const { createEventEmitterProxy } = require('@metamask/swappable-obj-proxy')
 
 const original = new EventEmitter()
 const next = new EventEmitter()

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "swappable-obj-proxy",
+  "name": "@metamask/swappable-obj-proxy",
   "version": "1.1.0",
   "description": "Tools for creating `Proxy`s around objects that are swappable via setTarget",
   "main": "src/index.js",
@@ -17,10 +17,10 @@
   "dependencies": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kumavis/eventemitter-proxy.git"
+    "url": "https://github.com/MetaMask/swappable-obj-proxy.git"
   },
   "bugs": {
-    "url": "https://github.com/kumavis/eventemitter-proxy/issues"
+    "url": "https://github.com/MetaMask/swappable-obj-proxy/issues"
   },
-  "homepage": "https://github.com/kumavis/eventemitter-proxy#readme"
+  "homepage": "https://github.com/MetaMask/swappable-obj-proxy#readme"
 }


### PR DESCRIPTION
Now that the repo for this package is hosted under our GitHub organization, we ought to republish any future changes under our NPM scope as well. This aligns with how we publish our other packages.