### PR TITLE
only migrate events that were added via the proxy

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -43,7 +43,7 @@ module.exports = {
     global: {
       branches: 90,
       functions: 94.11,
-      lines: 92.3,
+      lines: 92.53,
       statements: 92.64,
     },
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 93.75,
+      branches: 94.87,
       functions: 94.11,
-      lines: 92.85,
-      statements: 92.95,
+      lines: 92.64,
+      statements: 92.75,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -43,7 +43,7 @@ module.exports = {
     global: {
       branches: 93.75,
       functions: 94.11,
-      lines: 92.64,
+      lines: 92.85,
       statements: 92.95,
     },
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 90,
-      functions: 94.11,
-      lines: 92.53,
-      statements: 92.64,
+      branches: 92.85,
+      functions: 93.75,
+      lines: 92.3,
+      statements: 92.42,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 92.85,
-      functions: 93.75,
-      lines: 92.3,
-      statements: 92.42,
+      branches: 93.75,
+      functions: 94.11,
+      lines: 92.64,
+      statements: 92.95,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 73.33,
-      functions: 92.85,
-      lines: 86.27,
-      statements: 86.53,
+      branches: 90,
+      functions: 94.11,
+      lines: 92.3,
+      statements: 92.64,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 94.87,
+      branches: 93.75,
       functions: 94.11,
-      lines: 92.64,
-      statements: 92.75,
+      lines: 92.85,
+      statements: 92.95,
     },
   },
 

--- a/src/createEventEmitterProxy.test.ts
+++ b/src/createEventEmitterProxy.test.ts
@@ -47,10 +47,10 @@ describe('createEventEmitterProxy', () => {
     });
 
     original.emit('event');
-    await new Promise((resolve) => setTimeout(resolve, 100))
+    await new Promise((resolve) => setTimeout(resolve, 100));
     original.emit('event');
     expect(sawEvent).toBe(1);
-    await new Promise((resolve) => setTimeout(resolve, 100))
+    await new Promise((resolve) => setTimeout(resolve, 100));
     proxy.setTarget(next);
     next.emit('event');
     next.emit('event');
@@ -312,7 +312,7 @@ describe('createEventEmitterProxy', () => {
     const original = new EventEmitter();
     const proxy = createEventEmitterProxy(original);
 
-    proxy.on.call(this, 'testEvent', function(this: typeof original) {
+    proxy.on.call(this, 'testEvent', function (this: typeof original) {
       expect(this).toBe(original);
     });
 

--- a/src/createEventEmitterProxy.test.ts
+++ b/src/createEventEmitterProxy.test.ts
@@ -121,7 +121,7 @@ describe('createEventEmitterProxy', () => {
 
     // only filter all events
     const proxy = createEventEmitterProxy(original, {
-      eventFilter: () => false
+      eventFilter: () => false,
     });
 
     let sawEvent = 0;
@@ -286,7 +286,7 @@ describe('createEventEmitterProxy', () => {
     const original = new EventEmitter();
     const proxy = createEventEmitterProxy(original);
 
-    proxy.on.call(this, 'testEvent', function(this: typeof original) {
+    proxy.on.call(this, 'testEvent', function (this: typeof original) {
       expect(this).toBe(original);
     });
 

--- a/src/createEventEmitterProxy.test.ts
+++ b/src/createEventEmitterProxy.test.ts
@@ -188,7 +188,7 @@ describe('createEventEmitterProxy', () => {
     original.on('shouldNotMove', () => (moveCount += 1));
 
     const proxy = createEventEmitterProxy(original);
-    expect(proxy.eventNames()).toStrictEqual(['shouldNotMove']);
+    expect(proxy.eventNames()[0]).toBe('shouldNotMove');
     proxy.on('shouldMove', () => (moveCount += 1));
     proxy.setTarget(next);
     next.emit('shouldMove');

--- a/src/createEventEmitterProxy.ts
+++ b/src/createEventEmitterProxy.ts
@@ -130,7 +130,7 @@ export function createEventEmitterProxy<Type extends EventEmitterLike>(
       const value = target[name];
 
       if (typeof value === 'function') {
-        return function (this: unknown, ...args: any[]) {
+        return function(this: unknown, ...args: any[]) {
           const unwrappedHandler = args[1];
           if (name === 'once') {
             const wrappedHandler = (...handlerArgs: any[]) => {

--- a/src/createEventEmitterProxy.ts
+++ b/src/createEventEmitterProxy.ts
@@ -123,7 +123,7 @@ export function createEventEmitterProxy<Type extends EventEmitterLike>(
       const value = target[name];
 
       if (typeof value === 'function') {
-        return function(this: unknown, ...args: any[]) {
+        return function (this: unknown, ...args: any[]) {
           if (name === 'once') {
             const unwrappedHandler = args[1];
             const wrappedHandler = (...handlerArgs: any[]) => {
@@ -142,7 +142,7 @@ export function createEventEmitterProxy<Type extends EventEmitterLike>(
               addedWith: name,
               name: args[0],
               handler: args[1],
-              filtered: !eventFilter(args[0])
+              filtered: !eventFilter(args[0]),
             });
           } else if (name === 'off' || name === 'removeListener') {
             removeEvent(args[0], args[1]);

--- a/src/createEventEmitterProxy.ts
+++ b/src/createEventEmitterProxy.ts
@@ -130,7 +130,7 @@ export function createEventEmitterProxy<Type extends EventEmitterLike>(
       const value = target[name];
 
       if (typeof value === 'function') {
-        return function(this: unknown, ...args: any[]) {
+        return function (this: unknown, ...args: any[]) {
           const unwrappedHandler = args[1];
           if (name === 'once') {
             const wrappedHandler = (...handlerArgs: any[]) => {

--- a/src/createEventEmitterProxy.ts
+++ b/src/createEventEmitterProxy.ts
@@ -105,7 +105,9 @@ export function createEventEmitterProxy<Type extends EventEmitterLike>(
   const removeEvent = (name: string, handler: EventDetails['handler']) => {
     eventsAdded = eventsAdded.filter(
       (addedEvent) =>
-        name !== addedEvent.name || (handler !== addedEvent.handler && handler !== addedEvent.unwrappedHandler),
+        name !== addedEvent.name ||
+        (handler !== addedEvent.handler &&
+          handler !== addedEvent.unwrappedHandler),
     );
   };
 
@@ -128,8 +130,8 @@ export function createEventEmitterProxy<Type extends EventEmitterLike>(
       const value = target[name];
 
       if (typeof value === 'function') {
-        return function(this: unknown, ...args: any[]) {
-          let unwrappedHandler = args[1];
+        return function (this: unknown, ...args: any[]) {
+          const unwrappedHandler = args[1];
           if (name === 'once') {
             const wrappedHandler = (...handlerArgs: any[]) => {
               removeEvent(args[0], wrappedHandler);
@@ -151,9 +153,14 @@ export function createEventEmitterProxy<Type extends EventEmitterLike>(
               filtered: !eventFilter(args[0]),
             });
           } else if (name === 'off' || name === 'removeListener') {
-            const eventAdded = eventsAdded.find(({ name, unwrappedHandler }) => name === args[0] && unwrappedHandler === args[1]);
+            const eventAdded = eventsAdded.find(
+              ({ name: addedName, unwrappedHandler: addedUnwrappedHandler }) =>
+                addedName === args[0] && addedUnwrappedHandler === args[1],
+            );
             // this should never really happen unless you've called removeListener for something that is already not there.
-            if (eventAdded === undefined) { return target; }
+            if (eventAdded === undefined) {
+              return target;
+            }
             removeEvent(args[0], args[1]);
             args[1] = eventAdded.handler;
           }

--- a/src/createEventEmitterProxy.ts
+++ b/src/createEventEmitterProxy.ts
@@ -130,7 +130,7 @@ export function createEventEmitterProxy<Type extends EventEmitterLike>(
       const value = target[name];
 
       if (typeof value === 'function') {
-        return function(this: unknown, ...args: any[]) {
+        return function (this: unknown, ...args: any[]) {
           const unwrappedHandler = args[1];
           if (name === 'once') {
             const wrappedHandler = (...handlerArgs: any[]) => {
@@ -157,8 +157,12 @@ export function createEventEmitterProxy<Type extends EventEmitterLike>(
               ({ name: addedName, unwrappedHandler: addedUnwrappedHandler }) =>
                 addedName === args[0] && addedUnwrappedHandler === args[1],
             );
+            // this should never really happen unless you've called removeListener for something that is already not there.
+            if (eventAdded === undefined) {
+              return target;
+            }
             removeEvent(args[0], args[1]);
-            args[1] = eventAdded?.handler ?? args[1];
+            args[1] = eventAdded.handler;
           }
 
           // This function may be either bound to something or nothing.

--- a/src/createEventEmitterProxy.ts
+++ b/src/createEventEmitterProxy.ts
@@ -46,6 +46,8 @@ const externalEventFilter = (name: string | symbol) =>
  * target can be substituted with another object later using its `setTarget`
  * method. In addition, when the target is changed, event listeners which have
  * been attached to the target will be detached and migrated to the new target.
+ * Note that events attached to the eventEmitter (not the proxy) will not be
+ * migrated or removed when calling `setTarget`.
  *
  * @template Type - An object that implements at least `eventNames`, `rawListeners`,
  * and `removeAllListeners` from [Node's EventEmitter interface](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/events.d.ts).

--- a/src/createEventEmitterProxy.ts
+++ b/src/createEventEmitterProxy.ts
@@ -130,7 +130,7 @@ export function createEventEmitterProxy<Type extends EventEmitterLike>(
       const value = target[name];
 
       if (typeof value === 'function') {
-        return function (this: unknown, ...args: any[]) {
+        return function(this: unknown, ...args: any[]) {
           const unwrappedHandler = args[1];
           if (name === 'once') {
             const wrappedHandler = (...handlerArgs: any[]) => {
@@ -157,12 +157,8 @@ export function createEventEmitterProxy<Type extends EventEmitterLike>(
               ({ name: addedName, unwrappedHandler: addedUnwrappedHandler }) =>
                 addedName === args[0] && addedUnwrappedHandler === args[1],
             );
-            // this should never really happen unless you've called removeListener for something that is already not there.
-            if (eventAdded === undefined) {
-              return target;
-            }
             removeEvent(args[0], args[1]);
-            args[1] = eventAdded.handler;
+            args[1] = eventAdded?.handler ?? args[1];
           }
 
           // This function may be either bound to something or nothing.

--- a/src/createEventEmitterProxy.ts
+++ b/src/createEventEmitterProxy.ts
@@ -135,10 +135,7 @@ export function createEventEmitterProxy<Type extends EventEmitterLike>(
             }
           }
           if (name === 'off' || name === 'removeListener') {
-            eventsAdded = eventsAdded.filter(
-              (addedEvent) =>
-                args[0] !== addedEvent.name || args[1] !== addedEvent.handler,
-            );
+            removeEvent(args[0], args[1]);
           }
 
           // This function may be either bound to something or nothing.

--- a/src/createEventEmitterProxy.ts
+++ b/src/createEventEmitterProxy.ts
@@ -18,11 +18,17 @@ type EventEmitterLike = {
 };
 
 type EventDetails = {
-  // the name of the event
+  /**
+   * The name of the event.
+   */
   name: string;
-  // the method given to handle the event
+  /**
+   * The method given to handle the event.
+   */
   handler: (...args: unknown[]) => unknown;
-  // name of the method used to add the event (on or prepend)
+  /**
+   * Name of the method used to add the event.
+   */
   addedWith: 'on' | 'prependListener' | 'addListener' | 'once';
 };
 


### PR DESCRIPTION
Added new test cases to validate the enhanced functionality of the EventEmitter proxy. These tests check behaviors like event migration only for events added via the proxy, exclusion of internally added events, and proper handling of 'off' and 'removeListener' methods.

Changed Significant updates to the logic of creating an EventEmitter proxy. The changes focus on ensuring that only events added through the proxy are migrated when switching targets. This involves tracking events added to the proxy and only migrating events that were tracked in this manner, thus avoiding migrating events that were not added via the proxy.

In summary, The logic of this PR aims to refine the EventEmitter proxy's behavior, particularly in how events are handled and migrated, ensuring more precise and controlled event management.

This also fixes an issue with/unblocks https://github.com/MetaMask/metamask-extension/pull/22202