### PR TITLE
feat(types): export EventEmitterLike

### DIFF
--- a/src/createEventEmitterProxy.ts
+++ b/src/createEventEmitterProxy.ts
@@ -1,21 +1,4 @@
-import type { SwappableProxy } from './types';
-
-/**
- * A portion of Node's EventEmitter interface that `createEventEmitterProxy`
- * expects its `target` to support.
- */
-type EventEmitterLike = {
-  eventNames: () => (string | symbol)[];
-  // The `rawListeners` method returns an array of `Function`s.
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  rawListeners(eventName: string | symbol): Function[];
-  removeAllListeners(event?: string | symbol): EventEmitterLike;
-  on(name: string, handler: (...args: unknown[]) => unknown): void;
-  prependListener(name: string, handler: (...args: unknown[]) => unknown): void;
-  addListener(name: string, handler: (...args: unknown[]) => unknown): void;
-  off(name: string, handler: (...args: unknown[]) => unknown): void;
-  once(name: string, handler: (...args: unknown[]) => unknown): void;
-};
+import type { SwappableProxy, EventEmitterLike } from './types';
 
 type EventDetails = {
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,20 @@
 export type SwappableProxy<Type extends object> = Type & {
   setTarget: (newTarget: Type) => void;
 };
+
+/**
+ * A portion of Node's EventEmitter interface that `createEventEmitterProxy`
+ * expects its `target` to support.
+ */
+export type EventEmitterLike = {
+  eventNames: () => (string | symbol)[];
+  // The `rawListeners` method returns an array of `Function`s.
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  rawListeners(eventName: string | symbol): Function[];
+  removeAllListeners(event?: string | symbol): EventEmitterLike;
+  on(name: string, handler: (...args: unknown[]) => unknown): void;
+  prependListener(name: string, handler: (...args: unknown[]) => unknown): void;
+  addListener(name: string, handler: (...args: unknown[]) => unknown): void;
+  off(name: string, handler: (...args: unknown[]) => unknown): void;
+  once(name: string, handler: (...args: unknown[]) => unknown): void;
+};


### PR DESCRIPTION
The `EventEmitterLike` interface is referenced in the exported function `createEventEmitterProxy`. It should therefore also be exported to avoiding users needing to redundantly redeclare it.

The `EventDetails` type is only used internally so can stay unexported.